### PR TITLE
Remove unused acct_res tracking in suspend handler

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -705,7 +705,6 @@ async def suspend_user(req: SuspendUserRequest):
     steps = []
 
     # Step 1: deactivate/disable/suspend account via everestctl (probe support to avoid noise)
-    acct_res = None
     try:
         help_res = await run_cmd(["everestctl", "accounts", "--help"], timeout=10)
         help_text = (help_res.get("stdout", "") + "\n" + help_res.get("stderr", "")).lower()
@@ -730,7 +729,6 @@ async def suspend_user(req: SuspendUserRequest):
             r.update({"name": "deactivate_account"})
             steps.append(r)
             if r.get("exit_code") == 0:
-                acct_res = r
                 break
     # Step 2: scale down DB workloads
     scale_res = None


### PR DESCRIPTION
## Summary
- remove the unused `acct_res` bookkeeping from the `suspend_user` handler
- keep the deactivate loop intact without storing the unused result reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9518df5a4832d8842dfd87a0f7e72