### PR TITLE
Refactor bootstrap workflow into reusable helpers

### DIFF
--- a/tests/test_bootstrap_job.py
+++ b/tests/test_bootstrap_job.py
@@ -2,7 +2,9 @@ import asyncio
 import pytest
 import httpx
 
-from app.app import app
+import app.app as app_module
+
+app = app_module.app
 
 
 @pytest.mark.asyncio
@@ -17,7 +19,6 @@ async def test_bootstrap_job_success(monkeypatch):
             return {"exit_code": 0, "stdout": stdout, "stderr": "", "command": " ".join(cmd)}
         return {"exit_code": 0, "stdout": stdout, "stderr": "", "command": " ".join(cmd)}
 
-    from app import app as app_module
     monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
 
     headers = {"X-Admin-Key": "changeme"}
@@ -45,3 +46,43 @@ async def test_bootstrap_job_success(monkeypatch):
         assert "add_namespace" in step_names
         assert "apply_resource_quota" in step_names
         assert "apply_rbac_policy" in step_names
+
+
+@pytest.mark.asyncio
+async def test_create_account_idempotent(monkeypatch):
+    async def fake_run_cmd(cmd, **kwargs):
+        return {
+            "exit_code": 1,
+            "stdout": "",
+            "stderr": "user already exists",
+            "command": " ".join(cmd),
+        }
+
+    monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
+    monkeypatch.setenv("BOOTSTRAP_DEFAULT_PASSWORD", "pw")
+
+    req = app_module.BootstrapRequest(username="alice")
+    outcome = await app_module._create_account(req)
+
+    assert outcome.succeeded is True
+    assert outcome.meta["account_existed"] is True
+    assert "********" in outcome.result.get("command", "")
+
+
+@pytest.mark.asyncio
+async def test_ensure_namespace_unknown_flag(monkeypatch):
+    calls = []
+
+    async def fake_run_cmd(cmd, **kwargs):
+        calls.append(cmd)
+        if any("--operator.mysql" in c for c in cmd):
+            return {"exit_code": 1, "stdout": "", "stderr": "unknown flag", "command": " ".join(cmd)}
+        return {"exit_code": 0, "stdout": "ok", "stderr": "", "command": " ".join(cmd)}
+
+    monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
+
+    req = app_module.BootstrapRequest(username="bob")
+    outcome = await app_module._ensure_namespace(req, "bob")
+
+    assert outcome.succeeded is True
+    assert any("--operator.xtradb-cluster" in c for cmd in calls for c in cmd)


### PR DESCRIPTION
## Summary
- introduce a reusable `StepOutcome` structure and async helpers for the bootstrap steps
- streamline `submit_bootstrap` to orchestrate the helper coroutines and aggregate status reporting
- extend the bootstrap job tests to cover the new helper behaviors and namespace fallback logic

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d952819704832db5411cb44c503d7b