### PR TITLE
Refactor blocking admin operations into background jobs

### DIFF
--- a/tests/test_day_to_day.py
+++ b/tests/test_day_to_day.py
@@ -1,20 +1,36 @@
-import pytest
+import asyncio
+
 import httpx
+import pytest
 
 from app.app import app
 
 
+async def _wait_for_job(ac: httpx.AsyncClient, job_id: str, headers: dict) -> dict:
+    for _ in range(40):
+        status = await ac.get(f"/jobs/{job_id}", headers=headers)
+        assert status.status_code == 200
+        body = status.json()
+        if body["status"] in {"succeeded", "failed"}:
+            return body
+        await asyncio.sleep(0.01)
+    raise AssertionError("job did not finish in time")
+
+
+async def _fetch_job_result(ac: httpx.AsyncClient, job_id: str, headers: dict) -> dict:
+    res = await ac.get(f"/jobs/{job_id}/result", headers=headers)
+    assert res.status_code == 200
+    return res.json()
+
+
 @pytest.mark.asyncio
 async def test_set_account_password(monkeypatch):
-    called = {}
-
     async def fake_run_cmd(cmd, **kwargs):
-        # Expect set-password command
         assert cmd[:4] == ["everestctl", "accounts", "set-password", "-u"]
-        called["cmd"] = cmd
         return {"exit_code": 0, "stdout": "ok", "stderr": "", "command": " ".join(cmd)}
 
     from app import app as app_module
+
     monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
 
     headers = {"X-Admin-Key": "changeme"}
@@ -25,18 +41,25 @@ async def test_set_account_password(monkeypatch):
             json={"username": "bob", "new_password": "s3cr3t"},
             headers=headers,
         )
-        assert r.status_code == 200
-        assert r.json()["ok"] is True
+        assert r.status_code == 202
+        job_id = r.json()["job_id"]
+
+        await _wait_for_job(ac, job_id, headers)
+        body = await _fetch_job_result(ac, job_id, headers)
+
+        assert body["ok"] is True
+        step_names = [s.get("name") for s in body.get("steps", [])]
+        assert "set_password_stdin" in step_names
 
 
 @pytest.mark.asyncio
 async def test_update_namespace_resources(monkeypatch):
     async def fake_run_cmd(cmd, **kwargs):
-        # Expect kubectl apply -n <ns> -f -
         assert cmd[:3] == ["kubectl", "apply", "-n"]
         return {"exit_code": 0, "stdout": "applied", "stderr": "", "command": " ".join(cmd)}
 
     from app import app as app_module
+
     monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
 
     headers = {"X-Admin-Key": "changeme"}
@@ -47,8 +70,14 @@ async def test_update_namespace_resources(monkeypatch):
             json={"namespace": "alice", "resources": {"cpu_cores": 1, "ram_mb": 512, "disk_gb": 2}},
             headers=headers,
         )
-        assert r.status_code == 200
-        assert r.json()["applied"] is True
+        assert r.status_code == 202
+        job_id = r.json()["job_id"]
+
+        await _wait_for_job(ac, job_id, headers)
+        body = await _fetch_job_result(ac, job_id, headers)
+
+        assert body["applied"] is True
+        assert body["ok"] is True
 
 
 @pytest.mark.asyncio
@@ -57,15 +86,19 @@ async def test_update_namespace_operators_with_fallback(monkeypatch):
 
     async def fake_run_cmd(cmd, **kwargs):
         calls["count"] += 1
-        # First call simulates unknown flag for --operator.mysql
         if calls["count"] == 1 and any("--operator.mysql" in c for c in cmd):
-            return {"exit_code": 1, "stdout": "", "stderr": "unknown flag: --operator.mysql", "command": " ".join(cmd)}
-        # Second call should include --operator.xtradb-cluster
+            return {
+                "exit_code": 1,
+                "stdout": "",
+                "stderr": "unknown flag: --operator.mysql",
+                "command": " ".join(cmd),
+            }
         if calls["count"] == 2 and any("--operator.xtradb-cluster" in c for c in cmd):
             return {"exit_code": 0, "stdout": "ok", "stderr": "", "command": " ".join(cmd)}
         return {"exit_code": 0, "stdout": "ok", "stderr": "", "command": " ".join(cmd)}
 
     from app import app as app_module
+
     monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
 
     headers = {"X-Admin-Key": "changeme"}
@@ -76,5 +109,13 @@ async def test_update_namespace_operators_with_fallback(monkeypatch):
             json={"namespace": "alice-ns", "operators": {"mongodb": True, "postgresql": True, "mysql": True}},
             headers=headers,
         )
-        assert r.status_code == 200
-        assert r.json()["ok"] is True
+        assert r.status_code == 202
+        job_id = r.json()["job_id"]
+
+        await _wait_for_job(ac, job_id, headers)
+        body = await _fetch_job_result(ac, job_id, headers)
+
+        assert body["ok"] is True
+        assert body["namespace"] == "alice-ns"
+        step_names = [s.get("name") for s in body.get("steps", [])]
+        assert "update_namespace_operators" in step_names

--- a/tests/test_suspend_delete.py
+++ b/tests/test_suspend_delete.py
@@ -1,18 +1,42 @@
+import asyncio
 import json
-import pytest
+
 import httpx
+import pytest
 
 from app.app import app
 
 
+async def _wait_for_job(ac: httpx.AsyncClient, job_id: str, headers: dict) -> dict:
+    for _ in range(40):
+        status = await ac.get(f"/jobs/{job_id}", headers=headers)
+        assert status.status_code == 200
+        data = status.json()
+        if data["status"] in {"succeeded", "failed"}:
+            return data
+        await asyncio.sleep(0.01)
+    raise AssertionError("job did not finish in time")
+
+
+async def _fetch_job_result(ac: httpx.AsyncClient, job_id: str, headers: dict) -> dict:
+    res = await ac.get(f"/jobs/{job_id}/result", headers=headers)
+    assert res.status_code == 200
+    return res.json()
+
+
 @pytest.mark.asyncio
 async def test_suspend_user_flow(monkeypatch):
-    # Simulate: no deactivate available (all variants fail), scale succeeds, RBAC revoke succeeds
-    calls = {"i": 0}
-
     async def fake_run_cmd(cmd, **kwargs):
-        calls["i"] += 1
         c = " ".join(cmd)
+        if cmd == ["everestctl", "accounts", "--help"]:
+            help_text = """
+Usage:
+  everestctl accounts deactivate
+  everestctl accounts disable
+  everestctl accounts suspend
+  everestctl accounts lock
+""".strip()
+            return {"exit_code": 0, "stdout": help_text, "stderr": "", "command": c}
         if cmd[:3] == ["everestctl", "accounts", "deactivate"]:
             return {"exit_code": 1, "stdout": "", "stderr": "unknown command", "command": c}
         if cmd[:3] == ["everestctl", "accounts", "disable"]:
@@ -34,8 +58,8 @@ async def test_suspend_user_flow(monkeypatch):
                         "g, alice, role:alice",
                         "p, role:bob, namespaces, read, team-bob",
                         "g, bob, role:bob",
-                    ])
-                }
+                    ]),
+                },
             }
             return {"exit_code": 0, "stdout": json.dumps(payload), "stderr": "", "command": c}
         if cmd[:2] == ["kubectl", "apply"]:
@@ -43,6 +67,7 @@ async def test_suspend_user_flow(monkeypatch):
         return {"exit_code": 0, "stdout": "ok", "stderr": "", "command": c}
 
     from app import app as app_module
+
     monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
 
     headers = {"X-Admin-Key": "changeme"}
@@ -53,8 +78,12 @@ async def test_suspend_user_flow(monkeypatch):
             json={"username": "bob", "namespace": "team-bob"},
             headers=headers,
         )
-        assert r.status_code == 200
-        body = r.json()
+        assert r.status_code == 202
+        job_id = r.json()["job_id"]
+
+        await _wait_for_job(ac, job_id, headers)
+        body = await _fetch_job_result(ac, job_id, headers)
+
         assert body["ok"] is True
         names = [s.get("name") for s in body.get("steps", [])]
         assert "scale_down_statefulsets" in names
@@ -63,7 +92,6 @@ async def test_suspend_user_flow(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_delete_user_flow_with_fallbacks(monkeypatch):
-    # Simulate: everestctl namespaces remove fails then kubectl delete succeeds; accounts delete succeeds
     async def fake_run_cmd(cmd, **kwargs):
         c = " ".join(cmd)
         if cmd[:3] == ["everestctl", "namespaces", "remove"]:
@@ -71,13 +99,16 @@ async def test_delete_user_flow_with_fallbacks(monkeypatch):
         if cmd[:3] == ["kubectl", "delete", "namespace"]:
             return {"exit_code": 0, "stdout": "namespace deleted", "stderr": "", "command": c}
         if cmd[:7] == ["kubectl", "-n", "everest-system", "get", "configmap", "everest-rbac", "-o"]:
-            # minimal CM with bob policy/binding
             payload = {
                 "apiVersion": "v1",
                 "kind": "ConfigMap",
                 "data": {
                     "enabled": "true",
-                    "policy.csv": "\n".join(["p, role:bob, namespaces, read, team-bob", "g, bob, role:bob"])},
+                    "policy.csv": "\n".join([
+                        "p, role:bob, namespaces, read, team-bob",
+                        "g, bob, role:bob",
+                    ]),
+                },
             }
             return {"exit_code": 0, "stdout": json.dumps(payload), "stderr": "", "command": c}
         if cmd[:2] == ["kubectl", "apply"]:
@@ -87,6 +118,7 @@ async def test_delete_user_flow_with_fallbacks(monkeypatch):
         return {"exit_code": 0, "stdout": "ok", "stderr": "", "command": c}
 
     from app import app as app_module
+
     monkeypatch.setattr(app_module, "run_cmd", fake_run_cmd)
 
     headers = {"X-Admin-Key": "changeme"}
@@ -97,10 +129,13 @@ async def test_delete_user_flow_with_fallbacks(monkeypatch):
             json={"username": "bob", "namespace": "team-bob"},
             headers=headers,
         )
-        assert r.status_code == 200
-        body = r.json()
+        assert r.status_code == 202
+        job_id = r.json()["job_id"]
+
+        await _wait_for_job(ac, job_id, headers)
+        body = await _fetch_job_result(ac, job_id, headers)
+
         assert body["ok"] is True
         step_names = [s.get("name") for s in body.get("steps", [])]
-        assert "delete_namespace" in step_names or "remove_namespace" in step_names
+        assert any(name in {"delete_namespace", "remove_namespace"} for name in step_names)
         assert "delete_account" in step_names
-


### PR DESCRIPTION
## Summary
- enqueue password reset, namespace management, and account suspension/deletion flows as background jobs that write detailed step results and job summaries
- update FastAPI handlers to return job identifiers for polling
- adjust async tests to poll the new job APIs when validating these operations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d97b118ca4832da64b34601c83b27b